### PR TITLE
lab3_list_smyshlaev

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -1,1 +1,212 @@
 #include <iostream>
+
+
+class List
+{
+public:
+	class Iterator;
+private:
+	class Node
+	{
+		friend class List::Iterator;
+		friend class List;
+		Node* Next;
+		int value;
+	public:
+		Node(int value, Node* next):Next(next),value(value) { };
+	};
+public:
+	class Iterator
+	{
+	private:
+		Node* ptr = nullptr;
+	public:
+		Iterator() :ptr(0) {}
+		Iterator(Node* p) : ptr(p) {}
+
+		int& operator*()
+		{
+			return ptr->value;
+		}
+		Node* operator->()
+		{
+			return ptr;
+		}
+
+		Iterator& operator++()
+		{
+			if(ptr)ptr = ptr->Next;
+			return *this;
+		}
+		Iterator operator++(int)
+		{
+			Iterator cp = *this;
+			if (ptr) ptr = ptr->Next;
+			return cp;
+		}
+		Iterator operator+(int j) const
+		{	
+			Node* curr = ptr;
+			while (curr && j > 0)
+			{
+				curr = curr->Next;
+				j--;
+			}
+			if (j > 0)
+			{
+				throw 0;
+			}
+			return Iterator(curr);
+		}
+		bool operator==(const Iterator& it) const
+		{
+			return (ptr == it.ptr);
+		}
+		bool operator!=(const Iterator& it) const
+		{
+			return (ptr != it.ptr);
+		}
+	};
+	public:
+	Iterator begin()
+	{
+		return Iterator(first);
+	}
+	Iterator end()
+	{
+		return Iterator(nullptr);
+	}
+
+	Node* first = nullptr;
+
+	List(int n = 0)
+	{
+		if (n < 0) throw 0;
+		while(n--)
+		{
+			Node* temp = new Node(0, first);
+			first = temp;
+		}
+	}
+	~List()
+	{
+		Node* curr;
+		while (first != nullptr)
+		{
+			curr = first->Next;
+			delete first;
+			first = curr;
+		}
+	}
+	List(const List& other)
+	{
+		Node* curr1 = other.first;
+		Node* curr2 = new Node(curr1->value, nullptr);
+		first = curr2;
+		while (curr1)
+		{
+			Node* next1 = curr1->Next;
+			if (!next1) break;
+			curr2->Next = new Node(next1->value, nullptr);
+			curr2 = curr2->Next;
+			curr1 = curr1->Next;
+		}
+	}
+	void print()
+	{
+		Node* tmp = first;
+		while (tmp)
+		{
+			std::cout << tmp->value;
+			tmp = tmp->Next;
+		}
+		std::cout << std::endl;
+	}
+	size_t size() const
+	{
+		size_t sz = 0;
+		Node* curr = first;
+		while (curr)
+		{
+			sz++;
+			curr = curr->Next;
+		}
+		return sz;
+	}
+	List(List&& other)
+	{
+		this->first = other.first;
+		other.first = nullptr;
+	}
+	int& operator[](int i)
+	{
+		if (i < 0)
+		{
+			throw 0;
+		}
+		Node* curr = first;
+		int count = 0;
+		while (curr != nullptr)
+		{
+			if (count == i)
+				return curr->value;
+			curr = curr->Next;
+			count++;
+		}
+		throw 0;
+	}
+	Node* operator[](Iterator it)
+	{
+		Node* curr = first;
+		Iterator it2 = begin();
+		while (curr != nullptr)
+		{
+			if (it2 == it)
+				return curr;
+			curr = curr->Next;
+			it2++;
+		}
+		throw 0;
+	}
+	Node* insert_after(int data,Node* prev)
+	{
+		
+		Node* tmp = new Node(data, nullptr);
+		tmp->Next = prev->Next;
+		prev->Next = tmp;
+		return tmp;
+	}
+	Node* insert_front(int data)
+	{
+		return(first = new Node(data, first));
+	}
+	void erase_after(Node* prev)
+	{
+		if (prev == nullptr) return;
+		Node* tmp = prev->Next;
+		if (tmp)
+		{
+			prev->Next = prev->Next->Next;
+			delete tmp;
+		}
+	}
+	void erase_front()
+	{
+		if (first == nullptr)
+			return;
+		Node* tmp = first;
+		first = first->Next;
+		delete tmp;
+	}
+	Iterator find(int value)
+	{
+		Node* curr = first;
+		while (curr)
+		{
+			if (curr->value == value)
+				return Iterator(curr);
+			curr = curr->Next;
+		}
+		return end();
+	}
+};

--- a/include/list.h
+++ b/include/list.h
@@ -133,7 +133,7 @@ public:
 		if (this == &other)
 			return *this;
 
-		this->~List();
+		clear();
 
 		Node* curr1 = other.first;
 		if (curr1)

--- a/include/list.h
+++ b/include/list.h
@@ -91,7 +91,7 @@ public:
 	~List()
 	{
 		Node* curr;
-		while (first != nullptr)
+		while (first)
 		{
 			curr = first->Next;
 			delete first;
@@ -101,16 +101,22 @@ public:
 	List(const List& other)
 	{
 		Node* curr1 = other.first;
-		Node* curr2 = new Node(curr1->value, nullptr);
-		first = curr2;
-		while (curr1)
+		
+		if (curr1)
 		{
-			Node* next1 = curr1->Next;
-			if (!next1) break;
-			curr2->Next = new Node(next1->value, nullptr);
-			curr2 = curr2->Next;
-			curr1 = curr1->Next;
+			Node* curr2 = new Node(curr1->value, nullptr);
+			first = curr2;
+
+			while (curr1)
+			{
+				Node* next1 = curr1->Next;
+				if (!next1) break;
+				curr2->Next = new Node(next1->value, nullptr);
+				curr2 = curr2->Next;
+				curr1 = curr1->Next;
+			}
 		}
+
 	}
 	void print()
 	{
@@ -121,6 +127,60 @@ public:
 			tmp = tmp->Next;
 		}
 		std::cout << std::endl;
+	}
+	List& operator=(const List& other)
+	{
+		if (this == &other)
+			return *this;
+
+		this->~List();
+
+		Node* curr1 = other.first;
+		if (curr1)
+		{
+			Node* curr2 = new Node(curr1->value, nullptr);
+			first = curr2;
+			while (curr1)
+			{
+				Node* next1 = curr1->Next;
+				if (!next1) break;
+				curr2->Next = new Node(next1->value, nullptr);
+				curr1 = curr1->Next;
+				curr2 = curr2->Next;
+			}
+		}
+		
+		return *this;
+	}
+	bool operator==(const List& other) const noexcept
+	{
+		if (size() != other.size()) return false;
+
+		Node* curr1 = first;
+		Node* curr2 = other.first;
+		while (curr1)
+		{
+			if (curr1->value != curr2->value) return false;
+			if (curr1->Next == nullptr) break;
+			curr1 = curr1->Next;
+			curr2 = curr2->Next;
+		}
+		return true;
+	}
+
+	void clear()
+	{
+		Node* curr;
+		while (first)
+		{
+			curr = first->Next;
+			delete first;
+			first = curr;
+		}
+	}
+	bool operator!=(const List& other) const noexcept
+	{
+		return !(*this == other);
 	}
 	size_t size() const
 	{
@@ -170,9 +230,9 @@ public:
 	}
 	Node* insert_after(int data,Node* prev)
 	{
-		
-		Node* tmp = new Node(data, nullptr);
-		tmp->Next = prev->Next;
+		if (prev == nullptr) throw 0;
+
+		Node* tmp = new Node(data, prev->Next);
 		prev->Next = tmp;
 		return tmp;
 	}
@@ -182,18 +242,15 @@ public:
 	}
 	void erase_after(Node* prev)
 	{
-		if (prev == nullptr) return;
+		if (prev == nullptr || prev->Next == nullptr) throw 0;
 		Node* tmp = prev->Next;
-		if (tmp)
-		{
-			prev->Next = prev->Next->Next;
-			delete tmp;
-		}
+		prev->Next = prev->Next->Next;
+		delete tmp;
 	}
 	void erase_front()
 	{
 		if (first == nullptr)
-			return;
+			throw 0;
 		Node* tmp = first;
 		first = first->Next;
 		delete tmp;

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -1,0 +1,50 @@
+#include <gtest.h>
+#include "list.h"
+
+TEST(Iterator, iterator_can_be_dereferenced) {
+    List l(3);
+    l[0] = 50;
+    EXPECT_EQ(*(l.begin()), 50);
+}
+
+TEST(Iterator, can_increment_iterator) {
+    List l(3);
+    l[1] = 50;
+    l[2] = 100;
+    List::Iterator it = l.begin();
+    it++;
+    EXPECT_EQ(*it,50);
+    ++it;
+    EXPECT_EQ(*it, 100);
+}
+
+TEST(Iterator, can_increase_iterator_by_value) {
+    List l(5);
+    l[4] = 100;
+    EXPECT_EQ(*(l.begin() + 4), 100);
+}
+
+TEST(Iterator, throws_when_add_too_large_value) {
+    List l(3);
+    
+    ASSERT_ANY_THROW(List::Iterator it = l.begin() + 4;);
+}
+
+TEST(Iterator, iterator_is_not_equal) {
+    List l(3);
+    List::Iterator it1 = l.begin();
+    List::Iterator it2 = it1;
+    ++it2;
+    EXPECT_TRUE(it1 != it2); 
+}
+
+TEST(Iterator, begin_is_equal_nullptr_in_empty_list) {
+    List l;
+    EXPECT_EQ(l.begin(), nullptr); 
+}
+
+TEST(Iterator, incrementing_past_end) {
+    List l(2);
+    List::Iterator it = l.begin()+2;
+    EXPECT_EQ(it, l.end());     
+}

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -25,6 +25,14 @@ TEST(List, can_copy_list)
 	EXPECT_EQ(l2.find(2), l2.begin() + 1);
 	EXPECT_EQ(l2.find(1), l2.begin() + 2);
 }
+TEST(List, can_copy_empty_list)
+{
+	List l;
+	List l2(l);
+
+	EXPECT_EQ(l2.size(), 0);
+	EXPECT_EQ(l2, l);
+}
 TEST(List, can_return_size)
 {
 	List l(6);
@@ -107,6 +115,14 @@ TEST(List, can_find_elem)
 	EXPECT_EQ(l.find(200), l.begin() + 2);
 }
 
+TEST(List, returns_iterator_end_if_elem_not_found)
+{
+	List l(2);
+	l[0] = 1;
+	l[1] = 2;
+
+	EXPECT_EQ(l.find(3), l.end());
+}
 TEST(List, throws_when_try_to_get_access_to_neg_index)
 {
 	List l(3);
@@ -125,10 +141,145 @@ TEST(List, throws_when_try_to_get_access_with_too_large_iterator)
 {
 	List l(3);
 
-	ASSERT_ANY_THROW(l[l.begin() + 5]);
+	ASSERT_ANY_THROW(l[l.begin() + 3]);
 }
 
 TEST(List, throws_when_create_list_with_neg_length)
 {
 	ASSERT_ANY_THROW(List l(-1));
+}
+
+TEST(List, can_assign_lists_of_equal_size)
+{
+	List l(3);
+	l[0] = 0;
+	l[1] = 1;
+	l[2] = 2;
+
+	List l2;
+	l2 = l;
+
+	EXPECT_EQ(l2, l);
+}
+
+TEST(List, can_assign_lists_of_not_eq_size)
+{
+	List l1(2);
+	l1[0] = 1;
+	l1[1] = 2;
+	List l2(4);
+	l2[0] = 1;
+	l2[1] = 2;
+	l2[2] = 3;
+	l2[3] = 4;
+
+	l2 = l1;
+
+	EXPECT_EQ(l2, l1);
+}
+
+TEST(List, can_assign_list_to_itself)
+{
+	List l1(2);
+	l1[0] = 1;
+	l1[1] = 2;
+
+	l1 = l1;
+
+	EXPECT_EQ(l1[0], 1);
+}
+
+TEST(list, can_assign_empty_list_to_not_empty)
+{
+	List l1;
+	List l2(2);
+	l2[0] = 1;
+	l2[1] = 2;
+
+	l2 = l1;
+
+	EXPECT_EQ(l2.size(), 0);
+	EXPECT_EQ(l2, l1);
+}
+TEST(List, can_compare_eq_lists_of_eq_size)
+{
+	List l1(2), l2(2);
+	l1[0] = 1;
+	l1[1] = 2;
+	l2[0] = 1;
+	l2[1] = 2;
+
+	EXPECT_EQ(true, l1 == l2);
+}
+TEST(List, can_compare_not_eq_lists_of_eq_size)
+{
+	List l1(2), l2(2);
+	l1[0] = 1;
+	l1[1] = 2;
+	l2[0] = 1;
+	l2[1] = 3;
+
+	EXPECT_EQ(false, l1 == l2);
+}
+TEST(List, can_clear_list)
+{
+	List l(3);
+	l[0] = 1;
+	l[1] = 2;
+	l[2] = 3;
+
+	l.clear();
+
+	EXPECT_EQ(l.first, nullptr);
+	EXPECT_EQ(l.size(), 0);
+}
+
+TEST(List, throws_when_insert_after_last_elem)
+{
+	List l1(3);
+	l1[0] = 1;
+	l1[1] = 2;
+	l1[2] = 3;
+
+	ASSERT_ANY_THROW(l1.insert_after(4, l1[l1.begin() + 3]));
+	
+}
+
+TEST(List, throws_when_insert_after_to_empty_list)
+{
+	List l;
+
+	ASSERT_ANY_THROW(l.insert_after(1, l[l.begin()]));
+}
+
+TEST(List, can_insert_front_to_empty_list)
+{
+	List l;
+
+	l.insert_front(1);
+
+	EXPECT_EQ(l[0], 1);
+	EXPECT_EQ(l.size(), 1);
+}
+
+TEST(List, throws_when_erase_front_from_empty_list)
+{
+	List l;
+
+	ASSERT_ANY_THROW(l.erase_front());
+}
+
+TEST(List, throws_when_erase_after_from_empty_list)
+{
+	List l;
+	ASSERT_ANY_THROW(l.erase_after(l[l.begin()]));
+}
+
+TEST(List, throws_when_erase_after_last_elem_of_list)
+{
+	List l(2);
+	l[0] = 1;
+	l[1] = 2;
+
+	ASSERT_ANY_THROW(l.erase_after(l[l.begin() +1]));
 }

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -1,0 +1,134 @@
+#include <gtest.h>
+#include "list.h"
+
+TEST(List, can_create_empty_list)
+{
+	List l;
+	EXPECT_EQ(l.size(), 0);
+}
+
+TEST(List, can_create_not_empty_list)
+{
+	List l(5);
+	EXPECT_EQ(l.size(), 5);
+}
+
+TEST(List, can_copy_list)
+{
+	List l;
+	l.insert_front(1);
+	l.insert_front(2);
+	l.insert_front(3);
+
+	List l2(l);
+	EXPECT_EQ(l2.find(3),l2.begin());
+	EXPECT_EQ(l2.find(2), l2.begin() + 1);
+	EXPECT_EQ(l2.find(1), l2.begin() + 2);
+}
+TEST(List, can_return_size)
+{
+	List l(6);
+	EXPECT_EQ(l.size(), 6);
+}
+TEST(List, move_constructor_work_correctly)
+{
+	List l1;
+	l1.insert_front(1);
+	l1.insert_front(2);
+	l1.insert_front(3);
+
+	List l2(l1);
+	List l3 = std::move(l1);
+
+	EXPECT_EQ(*(l2.begin()), *(l3.begin()));
+	EXPECT_EQ(*(l2.begin() + 1), *(l3.begin() + 1));
+	EXPECT_EQ(*(l2.begin() + 2), *(l3.begin() + 2));
+	EXPECT_EQ(l1.size(), 0);
+}
+TEST(List, can_get_access_to_elem)
+{
+	List l(3);
+	l[0] = 1;
+	l[1] = 10;
+
+	EXPECT_EQ(l[0], 1);
+	EXPECT_EQ(l[1], 10);
+}
+
+TEST(List, can_insert_after)
+{
+	List l(2);
+	l[0] = 1;
+	l[1] = 2;
+	l.insert_after(10,l[l.begin() + 1]);
+	EXPECT_EQ(l.size(), 3);
+	EXPECT_EQ(l[2], 10);
+}
+
+TEST(List, can_insert_front)
+{
+	List l(2);
+	l[0] = 1;
+	l[1] = 2;
+	l.insert_front(3);
+
+	EXPECT_EQ(l.size(), 3);
+	EXPECT_EQ(l[0], 3);
+}
+
+TEST(List, can_erase_after)
+{
+	List l(2);
+
+	l[0] = 1;
+	l[1] = 10;
+
+	l.erase_after(l[l.begin()]);
+	EXPECT_EQ(l.size(), 1);
+	EXPECT_EQ(l[0], 1);
+}
+
+TEST(List, can_erase_front)
+{
+	List l(2);
+
+	l[0] = 1;
+	l[1] = 10;
+
+	l.erase_front();
+	EXPECT_EQ(l.size(), 1);
+	EXPECT_EQ(l[0], 10);
+}
+TEST(List, can_find_elem)
+{
+	List l(3);
+	l[2] = 200;
+
+	EXPECT_EQ(l.find(200), l.begin() + 2);
+}
+
+TEST(List, throws_when_try_to_get_access_to_neg_index)
+{
+	List l(3);
+
+	ASSERT_ANY_THROW(l[-1]);
+}
+
+TEST(List, throws_when_try_to_get_access_to_too_large_index)
+{
+	List l(3);
+
+	ASSERT_ANY_THROW(l[4]);
+}
+
+TEST(List, throws_when_try_to_get_access_with_too_large_iterator)
+{
+	List l(3);
+
+	ASSERT_ANY_THROW(l[l.begin() + 5]);
+}
+
+TEST(List, throws_when_create_list_with_neg_length)
+{
+	ASSERT_ANY_THROW(List l(-1));
+}


### PR DESCRIPTION
Реализован класс список с итератором, написаны тесты к классам list и iterator. 
Решил добавить перегрузку для operator[], так как мне показалось нехорошо возвращать доступ к объекту Node по ссылке. Сделал, чтобы при помещении в скобках итератора возвращался указатель на Node, в таком случае возвращаемое значение можно использовать в insert_after, при этом к полям Node пользователь напрямую не имеет. (при этом у начальной версии operator[] изменил возвращаемое значение на int& и возвращаю по ссылке value нужного элемента)
Для того, чтобы классы Node, Iterator и List не кофликтовали в силу private полей Node, подружил классы List и Node, Iterator и Node. 